### PR TITLE
Fixed whitespace, capitalized 'template', shortened licenseTypes

### DIFF
--- a/lice.js
+++ b/lice.js
@@ -1,32 +1,28 @@
-var _=require("underscore"); //use for string interpolation out of laziness
-var template=require("./licenseTemplate.js");
+var _ = require("underscore"); //use for string interpolation out of laziness
+var Template = require("./licenseTemplate.js");
 
-var templates =require('./templates.json');
+var templates = require('./templates.json');
 //http://underscorejs.org/#template // a la mustache
 _.templateSettings = {
 	interpolate : /\{\{(.+?)\}\}/g
 };
 
-var licenseTypes=function(){
-	var types=[];
-    for (var key in templates){
-        types.push(key);
-    }
-    return types;
+var licenseTypes = function() {
+	return Object.keys(templates)
 }
 
-var createLicense=function(licenseType, options, callback){
-    var templateInput=templates[licenseType];
-    var licenseTemplate=new template(templateInput);
-    var license=licenseTemplate.licenseWithOptions(options);
+var createLicense = function(licenseType, options, callback){
+	var templateInput = templates[licenseType];
+	var licenseTemplate = new Template(templateInput);
+	var license = licenseTemplate.licenseWithOptions(options);
 	callback(null, license);
 }
 
-var licenseVars=function(licenseType, callback){
-    var licenseTemplate=new template(templateInput);
-    return licenseTemplate.vars;
+var licenseVars = function(licenseType, callback){
+	var licenseTemplate = new Template(templateInput);
+	return licenseTemplate.vars;
 }
 
-exports.createLicense=createLicense;
-exports.licenseTypes=licenseTypes;
-exports.createLicense=createLicense;
+exports.createLicense = createLicense;
+exports.licenseTypes = licenseTypes;
+exports.createLicense = createLicense;


### PR DESCRIPTION
Put spaces around '='s.
Changed mixed spaces and tabs to tabs only.
Renamed 'template' to 'Template' (it is a javascript convention)
Shortened 'licenseTypes()'
(did not test)
